### PR TITLE
[ODS-6641] ODS-API-Upgrade-Scripts has a lot of warnings and very low score.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/**/*    @Ed-Fi-Alliance-OSS/ods-platform-automation-owners

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,94 @@
+# Ed-Fi Contributor Code of Conduct
+
+## Our Pledge
+
+The Ed-Fi Alliance community is made up of technology and education
+professionals committed to using data to drive better student outcomes.
+
+We, as members, contributors, and leaders, pledge to make participation in the
+community a harassment-free experience for everyone, regardless of how you
+identify yourself or how others perceive you. We pledge to act and interact in
+ways that contribute to an open, welcoming, diverse, inclusive, and healthy
+community.
+
+This Code of Conduct applies within all community spaces - virtual and in
+person.
+
+## Our Standards of Community Engagement
+
+We strive to hold each other to high standards of community engagement and
+collaboration. To do so, we encourage behavior that contributes to a positive
+environment, such as:
+
+* Demonstrating empathy and kindness toward others
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility for and apologizing to those affected by our
+  mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+We define harassment as any unwelcome conduct or behavior that creates a
+hostile, intimidating, or offensive environment. Examples of unacceptable
+behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[governance@ed-fi.org](mailto:governance@ed-fi.org) or individually to any
+member of the [Governance Advisory Team](https://www.ed-fi.org/community/). All
+complaints will be handled with discretion and respect and will be reviewed and
+investigated promptly and fairly.
+
+All members of the Ed-Fi Alliance staff and community leaders are obligated to
+respect the privacy and security of  any incident reported.
+
+## Enforcement Guidelines
+
+Community governance leaders will follow these guidelines determining the
+consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+A private, written warning from community leaders, providing clarity around the
+nature of the violation and an explanation of why the behavior was
+inappropriate. A public or private apology may be requested.
+
+### 2. Warning
+
+A warning with consequences for continued behavior. No interaction with the
+people involved, including unsolicited interaction with those enforcing the Code
+of Conduct, for a specified period. This includes avoiding interactions in
+community spaces as well as external channels like social media. Violating these
+terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+A temporary ban from any sort of interaction or public communication with the
+community for a specified period. No public or private interaction with the
+people involved, including unsolicited interaction with those enforcing the Code
+of Conduct, is allowed during this period. Violating these terms may lead to a
+permanent ban.
+
+### 4. Permanent Ban
+
+A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant, version
+2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+Original version by Coraline Ada Ehmke, licensed under [CC BY 4.0
+Deed](https://creativecommons.org/licenses/by/4.0/deed.en).


### PR DESCRIPTION
- Added Code of Conduct
- Dismissed unrelated alerts
- [Maintained](https://github.com/Ed-Fi-Alliance-OSS/ODS-API-Upgrade-Scripts/security/code-scanning/7) and [Code-Review](https://github.com/Ed-Fi-Alliance-OSS/ODS-API-Upgrade-Scripts/security/code-scanning/5) alerts should be closed after one or 2 more PRs reviewd and merged.
- [Branch-Protection](https://github.com/Ed-Fi-Alliance-OSS/ODS-API-Upgrade-Scripts/security/code-scanning/2) alert requires and admin to configure remediation steps